### PR TITLE
make git info accessible by datadog-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM amazoncorretto:17
 # Install dependencies
 RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
 RUN yum -y update
+RUN yum -y install git
 RUN yum -y install unzip
 RUN yum -y install util-linux
 RUN yum -y install nodejs # for npm

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -3,3 +3,4 @@ Component,Origin,License,Copyright
 @nodejs/node,core,MIT,"Copyright OpenJS Foundation and Node.js contributors"
 unzip,core,BSD-3-Clause,"Copyright (c) 1990-2009 Info-ZIP. All rights reserved"
 util-linux,core,GPL-2.0,"The Authors: https://github.com/util-linux/util-linux/blob/master/AUTHORS"
+git,https://github.com/git/git,GPL-2.0,© 2005-2023, Linus Torvalds and others.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -116,7 +116,7 @@ echo "Done"
 
 # navigate to workspace root, so the datadog-ci command can access the git info
 cd ${GITHUB_WORKSPACE} || exit 1
-git config --global --add safe.directory ${GITHUB_WORKSPACE}
+git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 echo "Uploading results to Datadog"
 ${DATADOG_CLI_PATH} sarif upload "$OUTPUT_FILE" --service "$DD_SERVICE" --env "$DD_ENV"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,7 +115,7 @@ $CLI_LOCATION --directory "${GITHUB_WORKSPACE}" -t true -o "$OUTPUT_FILE" -f sar
 echo "Done"
 
 # navigate to workspace root, so the datadog-ci command can access the git info
-cd ${GITHUB_WORKSPACE}
+cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
 echo "Uploading results to Datadog"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,6 +114,9 @@ echo "Starting a static analysis"
 $CLI_LOCATION --directory "${GITHUB_WORKSPACE}" -t true -o "$OUTPUT_FILE" -f sarif || exit 1
 echo "Done"
 
+# navigate to workspace root, so the datadog-ci command can access the git info
+cd ${GITHUB_WORKSPACE}
+git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
 echo "Uploading results to Datadog"
 ${DATADOG_CLI_PATH} sarif upload "$OUTPUT_FILE" --service "$DD_SERVICE" --env "$DD_ENV"


### PR DESCRIPTION
## What problem are you trying to solve?

The `datadog-ci` cannot pick up some git information as it's executed outside of it's scope and `git` is not installed.

## What is your solution?

Install `git`, `cd` into the working directory, and mark the directory as safe.

## Alternatives considered

None

## What the reviewer should know

Since `git` was installed, we've added it to the `LICENSE-3rdparty.csv` file.