### PR TITLE
Use only major version to install the Github Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1.0.0
+        uses: DataDog/datadog-static-analyzer-github-action@v1
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
## What problem are you trying to solve?
The snippet of code used to illustrate how to use the Github Action needs to be updated every time we release a minor or bugfix version of the GHA. This might imply the customer will not use the most updated version of the Github Action either.

## What is your solution?
Use the short form `@v1` to set only the major version, allowing the customer to use always the most latest released version of the GHA.

## What the reviewer should know
This action has a `v1` tag that points to the latest released version.