### PR TITLE
Get result SHA fingerprint with `-g` option

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,9 +129,6 @@ echo "Starting a static analysis"
 $CLI_LOCATION -g -i "${GITHUB_WORKSPACE}" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" || exit 1
 echo "Done"
 
-// TODO: remove me
-cat "$OUTPUT_FILE"
-
 echo "Uploading results to Datadog"
 ${DATADOG_CLI_PATH} sarif upload "$OUTPUT_FILE" --service "$DD_SERVICE" --env "$DD_ENV" || exit 1
 echo "Done"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,13 +121,16 @@ echo "Done: will output results at $OUTPUT_FILE"
 # execute the tool and upload results
 ########################################################
 
-echo "Starting a static analysis"
-$CLI_LOCATION -i "${GITHUB_WORKSPACE}" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" || exit 1
-echo "Done"
-
 # navigate to workspace root, so the datadog-ci command can access the git info
 cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
+
+echo "Starting a static analysis"
+$CLI_LOCATION -g -i "${GITHUB_WORKSPACE}" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" || exit 1
+echo "Done"
+
+// TODO: remove me
+cat "$OUTPUT_FILE"
 
 echo "Uploading results to Datadog"
 ${DATADOG_CLI_PATH} sarif upload "$OUTPUT_FILE" --service "$DD_SERVICE" --env "$DD_ENV" || exit 1


### PR DESCRIPTION
## What problem are you trying to solve?

We want to store the SHA of the last commit that updated a file where we report a violation.

## What is your solution?

This PR adds the `-g` option to our analyzer to get an SHA, if available, outputted in `result.partialFingerprints.SHA`.

## Alternatives considered

None

## What the reviewer should know

Without `fetch-depth: 0` in the checkout command, this information will not be available.

## Verification

These [5 violations](https://app.datadoghq.com/ci/static-analysis?query=service%3Astatic-analyzer-test-repo&currentTab=event&index=cicodescan&start=1692891221301&end=1692892100313&paused=true) all include their SHA. [This one in particular](https://app.datadoghq.com/ci/static-analysis?query=service%3Astatic-analyzer-test-repo&currentTab=event&index=cicodescan&staticAnalysisId=AgAAAYooMQaRdcIb8QAAAAAAAAAYAAAAAEFZb29NUDlWQUFDRldvWlZQOTdnQUFBQQAAACQAAAAAMDE4YTI4MzItYjQyMC00ZWIxLWI4NzQtYjYwMjM4YjQ0YWQz&trace=AgAAAYooMQaRdcIb8QAAAAAAAAAYAAAAAEFZb29NUDlWQUFDRldvWlZQOTdnQUFBQQAAACQAAAAAMDE4YTI4MzItYjQyMC00ZWIxLWI4NzQtYjYwMjM4YjQ0YWQz&start=1692891221301&end=1692892100313&paused=true) has the SHA: `dd749e1387c52c98976a38e88f46f76203f824de` which corresponds with where the [change was pushed](https://github.com/DataDog/datadog-static-analyzer-test-repo/commit/dd749e1387c52c98976a38e88f46f76203f824de).