### PR TITLE
Add subdirectory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can set the following parameters for Static Analysis.
 | `cpu_count`  | Set the number of CPUs used to by the analyzer.                                                                            | No      | `2`             |
 | `enable_performance_statistics` | Get the execution time statistics for analyzed files.                                                   | No      | `false`         |
 | `debug`      | Lets the analyzer print additional logs useful for debugging. To enable, set to `yes`.                                     | No      | `no`            |
-| `subdirectory` | A subdirectory path to run an analysis in. The path is relative to the root directory of your repository.                | No      |                 |
+| `subdirectory` | The subdirectory path the analysis should be limited to. The path is relative to the root directory of the repository.   | No      |                 |
 
 [1]: https://docs.datadoghq.com/account_management/api-app-keys/
 [2]: https://docs.github.com/en/actions/security-guides/encrypted-secrets

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can set the following parameters for Static Analysis.
 | `cpu_count`  | Set the number of CPUs used to by the analyzer.                                                                            | No      | `2`             |
 | `enable_performance_statistics` | Get the execution time statistics for analyzed files.                                                   | No      | `false`         |
 | `debug`      | Lets the analyzer print additional logs useful for debugging. To enable, set to `yes`.                                     | No      | `no`            |
+| `subdirectory` | A subdirectory path to run an analysis in. The path is relative to the root directory of your repository.                | No      |                 |
 
 [1]: https://docs.datadoghq.com/account_management/api-app-keys/
 [2]: https://docs.github.com/en/actions/security-guides/encrypted-secrets

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Lets the analyzer print additional logs useful for debugging."
     required: false
     default: "no"
+  subdirectory:
+    description: "A subdirectory path to run an analysis from."
+    required: false
+    default: ""
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -46,3 +50,4 @@ runs:
     CPU_COUNT: ${{ inputs.cpu_count }}
     ENABLE_PERFORMANCE_STATISTICS: ${{ inputs.enable_performance_statistics }}
     ENABLE_DEBUG: ${{ inputs.debug }}
+    SUBDIRECTORY: ${{ inputs.subdirectory }}

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: "no"
   subdirectory:
-    description: "A subdirectory path to run an analysis from."
+    description: "The subdirectory path the analysis should be limited to."
     required: false
     default: ""
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,6 +58,13 @@ if [ -z "$DD_SERVICE" ]; then
     exit 1
 fi
 
+# if a subdirectory is set, then we need to disable the addition of git information
+if [ -n "$SUBDIRECTORY" ]; then 
+    GIT_INFO_FLAG="-g";
+else 
+    GIT_INFO_FLAG="";  
+fi
+
 if [ -z "$CPU_COUNT" ]; then
     # the default CPU count is 2
     CPU_COUNT=2
@@ -132,7 +139,7 @@ cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 echo "Starting a static analysis"
-$CLI_LOCATION -g -i "${GITHUB_WORKSPACE}/${SUBDIRECTORY}" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE || exit 1
+$CLI_LOCATION -g -i "${GITHUB_WORKSPACE}/${SUBDIRECTORY}" "$GIT_INFO_FLAG" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE || exit 1
 echo "Done"
 
 echo "Uploading results to Datadog"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,9 +76,9 @@ else
 fi
 
 if [ -z "$SUBDIRECTORY" ]; then 
-    SUBDIRECTORY_OPTION="--subdirectory ${SUBDIRECTORY}"
-else 
     SUBDIRECTORY_OPTION=""
+else
+    SUBDIRECTORY_OPTION="--subdirectory ${SUBDIRECTORY}"
 fi
 
 ########################################################

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,7 @@ if [ -z "$DD_SERVICE" ]; then
 fi
 
 # if a subdirectory is set, then we need to disable the addition of git information
-if [ -n "$SUBDIRECTORY" ]; then 
+if [ -z "$SUBDIRECTORY" ]; then 
     GIT_INFO_FLAG="-g";
 else 
     GIT_INFO_FLAG="";  

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,7 +139,7 @@ cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 echo "Starting a static analysis"
-$CLI_LOCATION -g -i "${GITHUB_WORKSPACE}/${SUBDIRECTORY}" "$GIT_INFO_FLAG" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE || exit 1
+$CLI_LOCATION -i "${GITHUB_WORKSPACE}/${SUBDIRECTORY}" "$GIT_INFO_FLAG" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE || exit 1
 echo "Done"
 
 echo "Uploading results to Datadog"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -132,7 +132,7 @@ cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 echo "Starting a static analysis"
-$CLI_LOCATION -g -i "${GITHUB_WORKSPACE}" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE || exit 1
+$CLI_LOCATION -g -i "${GITHUB_WORKSPACE}/${SUBDIRECTORY}" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE || exit 1
 echo "Done"
 
 echo "Uploading results to Datadog"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,13 +58,6 @@ if [ -z "$DD_SERVICE" ]; then
     exit 1
 fi
 
-# if a subdirectory is set, then we need to disable the addition of git information
-if [ -z "$SUBDIRECTORY" ]; then 
-    GIT_INFO_FLAG="-g";
-else 
-    GIT_INFO_FLAG="";  
-fi
-
 if [ -z "$CPU_COUNT" ]; then
     # the default CPU count is 2
     CPU_COUNT=2
@@ -80,6 +73,12 @@ if [ "$ENABLE_DEBUG" = "yes" ]; then
     DEBUG_ARGUMENT_VALUE="yes"
 else
     DEBUG_ARGUMENT_VALUE="no"
+fi
+
+if [ -z "$SUBDIRECTORY" ]; then 
+    SUBDIRECTORY_OPTION="--subdirectory ${SUBDIRECTORY}"
+else 
+    SUBDIRECTORY_OPTION=""
 fi
 
 ########################################################
@@ -139,7 +138,7 @@ cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 echo "Starting a static analysis"
-$CLI_LOCATION -i "${GITHUB_WORKSPACE}/${SUBDIRECTORY}" "$GIT_INFO_FLAG" -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE || exit 1
+$CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION|| exit 1
 echo "Done"
 
 echo "Uploading results to Datadog"


### PR DESCRIPTION
## What problem are you trying to solve?

We want to allow users to run an analyze from a subdirectory. 

## What is your solution?

Support the analyzer's subdirectory option.

## Verification

**When no subdirectory is passed**
<img width="536" alt="Screenshot 2023-10-29 at 4 30 33 PM" src="https://github.com/DataDog/datadog-static-analyzer-github-action/assets/33348592/fba7253f-af61-4c7b-966a-c028a828eef5">

**A directory (`subway`) is set**
<img width="530" alt="Screenshot 2023-10-29 at 4 31 11 PM" src="https://github.com/DataDog/datadog-static-analyzer-github-action/assets/33348592/606294bd-21a8-436b-8dcf-43afd5446169">

**A directory (`/subway`) is set**
<img width="959" alt="Screenshot 2023-10-29 at 4 31 49 PM" src="https://github.com/DataDog/datadog-static-analyzer-github-action/assets/33348592/37eb3283-00a1-4a04-aaae-2abbe7ab6463">





