### PR TITLE
Remove pinned datadog-ci version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,7 +94,7 @@ CLI_LOCATION=$TOOL_DIRECTORY/datadog-static-analyzer
 # datadog-ci stuff
 ########################################################
 echo "Installing 'datadog-ci'"
-npm install -g @datadog/datadog-ci@2.16.1 || exit 1
+npm install -g @datadog/datadog-ci || exit 1
 
 DATADOG_CLI_PATH=/usr/bin/datadog-ci
 


### PR DESCRIPTION
## What problem are you trying to solve?

We previously pinned the `datadog-ci` package, but with integration testing for the sarif update been added since, we're comfortable remove the last guaranteed working version. 

## What is your solution?

Remove pinned version.