### PR TITLE
[STAL-747] Add SCA to the GitHub Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ FROM ubuntu:22.04
 RUN apt-get update
 RUN apt-get install -y git unzip curl ca-certificates gnupg
 
+# Install trivy
+RUN apt-get install -y wget apt-transport-https gnupg lsb-release
+RUN wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | apt-key add -
+RUN echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | tee -a /etc/apt/sources.list.d/trivy.list
+RUN apt-get update
+RUN apt-get install -y trivy
+
 # Install node 16
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 ENV NODE_MAJOR=16

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -6,3 +6,4 @@ util-linux,core,GPL-2.0,"The Authors: https://github.com/util-linux/util-linux/b
 git,https://github.com/git/git,GPL-2.0,© 2005-2023, Linus Torvalds and others.
 ca-certificate,core,GPL-2+,"Various Debian Contributors"
 gnupg,core,GPL-3+,"1992, 1995-2020, Free Software Foundation, Inc"
+trivy,https://github.com/aquasecurity/trivy,Apache-2.0,"Copyright (c) 2019 Aqua Security Limited"

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Lets the analyzer print additional logs useful for debugging."
     required: false
     default: "no"
+  sca_enabled:
+    description: "Enable Software Composition Analysis (SCA)"
+    required: false
+    default: "false"
   subdirectory:
     description: "The subdirectory path the analysis should be limited to."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -55,3 +55,4 @@ runs:
     ENABLE_PERFORMANCE_STATISTICS: ${{ inputs.enable_performance_statistics }}
     ENABLE_DEBUG: ${{ inputs.debug }}
     SUBDIRECTORY: ${{ inputs.subdirectory }}
+    SCA_ENABLED: ${{ inputs.sca_enabled }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -151,10 +151,15 @@ echo "Done"
 if [ "${SCA_ENABLED}" = "true" ] || [ "${SCA_ENABLED}" = "yes" ]; then
   SCA_OUTPUT_FILE="$OUTPUT_DIRECTORY/trivy.json"
   echo "Generating SBOM"
-  trivy fs --output "${SCA_OUTPUT_FILE}" --format cyclonedx .
-  echo "Done"
-  echo "Uploading results to Datadog"
-  DD_BETA_COMMANDS_ENABLED=1 ${DATADOG_CLI_PATH} sbom upload --service "$DD_SERVICE" --env "$DD_ENV" "${SCA_OUTPUT_FILE}" || exit 1
+  trivy fs --output "${SCA_OUTPUT_FILE}" --format cyclonedx . > /dev/null 2>&1
+
+  if [ -f "${SCA_OUTPUT_FILE}" ]; then
+    echo "Uploading SBOM to Datadog"
+    DD_BETA_COMMANDS_ENABLED=1 ${DATADOG_CLI_PATH} sbom upload --service "$DD_SERVICE" --env "$DD_ENV" "${SCA_OUTPUT_FILE}" || exit 1
+    echo "Done"
+  else
+    echo "SBOM not generated, not uploading"
+  fi
   echo "Done"
 else
   echo "SCA not enabled (sca_enabled value ${SCA_ENABLED}), skipping"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -146,7 +146,7 @@ ${DATADOG_CLI_PATH} sarif upload "$OUTPUT_FILE" --service "$DD_SERVICE" --env "$
 echo "Done"
 
 ########################################################
-# SCA
+# SCA/SBOM
 ########################################################
 if [ "${SCA_ENABLED}" = "true" ] || [ "${SCA_ENABLED}" = "yes" ]; then
   SCA_OUTPUT_FILE="$OUTPUT_DIRECTORY/trivy.json"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -159,6 +159,7 @@ if [ "${SCA_ENABLED}" = "true" ] || [ "${SCA_ENABLED}" = "yes" ]; then
     echo "Done"
   else
     echo "SBOM not generated, not uploading"
+    exit 1
   fi
   echo "Done"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ fi
 
 if [ "$ENABLE_PERFORMANCE_STATISTICS" = "true" ]; then
     ENABLE_PERFORMANCE_STATISTICS="--performance-statistics"
-else 
+else
     ENABLE_PERFORMANCE_STATISTICS=""
 fi
 
@@ -75,7 +75,7 @@ else
     DEBUG_ARGUMENT_VALUE="no"
 fi
 
-if [ -z "$SUBDIRECTORY" ]; then 
+if [ -z "$SUBDIRECTORY" ]; then
     SUBDIRECTORY_OPTION=""
 else
     SUBDIRECTORY_OPTION="--subdirectory ${SUBDIRECTORY}"
@@ -137,10 +137,24 @@ echo "Done: will output results at $OUTPUT_FILE"
 cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
-echo "Starting a static analysis"
+echo "Starting Static Analysis"
 $CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION|| exit 1
 echo "Done"
 
-echo "Uploading results to Datadog"
+echo "Uploading Static Analysis Results to Datadog"
 ${DATADOG_CLI_PATH} sarif upload "$OUTPUT_FILE" --service "$DD_SERVICE" --env "$DD_ENV" || exit 1
 echo "Done"
+
+########################################################
+# SCA
+########################################################
+
+if [ "${SCA_ENABLED}" = "true" ] || [ "${SCA_ENABLED}" = "yes" ]; then
+  SCA_OUTPUT_FILE="$OUTPUT_DIRECTORY/trivy.json"
+  echo "Generating SBOM"
+  trivy fs --output "${SCA_OUTPUT_FILE}" --format cyclonedx .
+  echo "Done"
+  echo "Uploading results to Datadog"
+  DD_BETA_COMMANDS_ENABLED=1 ${DATADOG_CLI_PATH} sbom upload --service "$DD_SERVICE" --env "$DD_ENV" "${SCA_OUTPUT_FILE}" || exit 1
+  echo "Done"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -148,7 +148,6 @@ echo "Done"
 ########################################################
 # SCA
 ########################################################
-
 if [ "${SCA_ENABLED}" = "true" ] || [ "${SCA_ENABLED}" = "yes" ]; then
   SCA_OUTPUT_FILE="$OUTPUT_DIRECTORY/trivy.json"
   echo "Generating SBOM"
@@ -157,4 +156,6 @@ if [ "${SCA_ENABLED}" = "true" ] || [ "${SCA_ENABLED}" = "yes" ]; then
   echo "Uploading results to Datadog"
   DD_BETA_COMMANDS_ENABLED=1 ${DATADOG_CLI_PATH} sbom upload --service "$DD_SERVICE" --env "$DD_ENV" "${SCA_OUTPUT_FILE}" || exit 1
   echo "Done"
+else
+  echo "SCA not enabled (sca_enabled value ${SCA_ENABLED}), skipping"
 fi


### PR DESCRIPTION
**What problem are we trying to solve?**

We want to include SCA (Software Composition Analysis) in our GitHub action so that SBOM are uploaded along with the static code analysis.

**Solution**

Add a new input `sca_enabled` (disable by default - set to `false`). When this value is either `"true"` or `"yes"`, the script:

1. Generate an SBOM with `trivy`
2. Check the file exists and was generated
3. Upload the file to Datadog.

**Testing**

Testing available in the corresponding JIRA ticket.