### PR TITLE
Support multiple architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can set the following parameters for Static Analysis.
 | `enable_performance_statistics` | Get the execution time statistics for analyzed files.                                                   | No      | `false`         |
 | `debug`      | Lets the analyzer print additional logs useful for debugging. To enable, set to `yes`.                                     | No      | `no`            |
 | `subdirectory` | The subdirectory path the analysis should be limited to. The path is relative to the root directory of the repository.   | No      |                 |
+| `architecture` | The CPU architecture to use for the analyzer. Supported values are `x86_64` and `aarch64`.                                 | No      | `x86_64`        |
 
 ## Further Reading
 

--- a/action.yml
+++ b/action.yml
@@ -43,9 +43,9 @@ inputs:
     required: false
     default: ""
   architecture:
-    description: "The architecture of the image to use."
+    description: "The architecture of the image to use. Can be x86_64 or aarch64."
     required: false
-    default: "x86_64-unknown-linux-gnu"
+    default: "x86_64"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: "The subdirectory path the analysis should be limited to."
     required: false
     default: ""
+  architecture:
+    description: "The architecture of the image to use."
+    required: false
+    default: "x86_64-unknown-linux-gnu"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -56,3 +60,4 @@ runs:
     ENABLE_DEBUG: ${{ inputs.debug }}
     SUBDIRECTORY: ${{ inputs.subdirectory }}
     SCA_ENABLED: ${{ inputs.sca_enabled }}
+    ARCHITECTURE: ${{ inputs.architecture }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,7 +92,7 @@ if [ ! -d "$TOOL_DIRECTORY" ]; then
 fi
 
 cd "$TOOL_DIRECTORY" || exit 1
-curl -L -o datadog-static-analyzer.zip https://github.com/DataDog/datadog-static-analyzer/releases/latest/download/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip >/dev/null 2>&1 || exit 1
+curl -L -o datadog-static-analyzer.zip https://github.com/DataDog/datadog-static-analyzer/releases/latest/download/datadog-static-analyzer-$ARCHITECTURE.zip >/dev/null 2>&1 || exit 1
 unzip datadog-static-analyzer >/dev/null 2>&1 || exit 1
 CLI_LOCATION=$TOOL_DIRECTORY/datadog-static-analyzer
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,6 +81,12 @@ else
     SUBDIRECTORY_OPTION="--subdirectory ${SUBDIRECTORY}"
 fi
 
+# verify ARCHITECTURE is x86_64 or aarch64
+if [ "$ARCHITECTURE" != "x86_64" ] && [ "$ARCHITECTURE" != "aarch64" ]; then
+    echo "ARCHITECTURE must be x86_64 or aarch64"
+    exit 1
+fi
+
 ########################################################
 # static analyzer tool stuff
 ########################################################
@@ -92,7 +98,7 @@ if [ ! -d "$TOOL_DIRECTORY" ]; then
 fi
 
 cd "$TOOL_DIRECTORY" || exit 1
-curl -L -o datadog-static-analyzer.zip https://github.com/DataDog/datadog-static-analyzer/releases/latest/download/datadog-static-analyzer-$ARCHITECTURE.zip >/dev/null 2>&1 || exit 1
+curl -L -o datadog-static-analyzer.zip https://github.com/DataDog/datadog-static-analyzer/releases/latest/download/datadog-static-analyzer-$ARCHITECTURE-unknown-linux-gnu.zip >/dev/null 2>&1 || exit 1
 unzip datadog-static-analyzer >/dev/null 2>&1 || exit 1
 CLI_LOCATION=$TOOL_DIRECTORY/datadog-static-analyzer
 


### PR DESCRIPTION
# What does this PR do?

This PR introduces the possibility for the user to select it's own architecture to run this github integration.

# Why is it needed?

Users may have self-host github runners with arm64-based CPUs (that's my case).

**Notes**:
- Current github-hosted runners are amd64-based but arm64 github-hosted runners will probably be available soon according to [this article](https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/).
- It keeps amd64 as a default value.
- Possiblie values for `architecture` parameter are the ones defined in [DataDog/datadog-static-analyzer](https://github.com/DataDog/datadog-static-analyzer/releases/) releases:
    - `architecture: x86_64` for amd64-based CPUs (default)
    - `architecture: aarch64` for arm64-based CPUs
- I could test it using `v1.3` [here](https://github.com/zetechmoy/datadog-static-analyzer-github-action/releases/tag/v1.3).