### PR TITLE
[STAL-1521] Add diff-aware scanning mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ You can set the following parameters for Static Analysis.
 | `enable_performance_statistics` | Get the execution time statistics for analyzed files.                                                   | No      | `false`         |
 | `debug`      | Lets the analyzer print additional logs useful for debugging. To enable, set to `yes`.                                     | No      | `no`            |
 | `subdirectory` | The subdirectory path the analysis should be limited to. The path is relative to the root directory of the repository.   | No      |                 |
-| `architecture` | The CPU architecture to use for the analyzer. Supported values are `x86_64` and `aarch64`.                                 | No      | `x86_64`        |
+| `architecture` | The CPU architecture to use for the analyzer. Supported values are `x86_64` and `aarch64`.                               | No      | `x86_64`        |
+| `diff_aware` | Enable [diff-aware scanning mode][5].                                                                                      | No      | `false`         |
 
 ## Further Reading
 
@@ -83,3 +84,4 @@ Additional helpful documentation, links, and articles:
 [2]: https://docs.datadoghq.com/account_management/api-app-keys/
 [3]: https://docs.datadoghq.com/getting_started/site/
 [4]: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
+[5]: https://github.com/DataDog/datadog-static-analyzer/blob/main/README.md#diff-aware-scanning

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: "The architecture of the image to use. Can be x86_64 or aarch64."
     required: false
     default: "x86_64"
+  diff_aware:
+    description: "Enable diff aware scanning mode."
+    required: false
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -61,3 +65,4 @@ runs:
     SUBDIRECTORY: ${{ inputs.subdirectory }}
     SCA_ENABLED: ${{ inputs.sca_enabled }}
     ARCHITECTURE: ${{ inputs.architecture }}
+    DIFF_AWARE: ${{ inputs.diff_aware }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -149,6 +149,10 @@ echo "Done: will output results at $OUTPUT_FILE"
 cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
+echo "Upload git metadata"
+${DATADOG_CLI_PATH} git-metadata upload || exit 1
+echo "Done"
+
 echo "Starting Static Analysis"
 $CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION $DIFF_AWARE_VALUE|| exit 1
 echo "Done"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -152,7 +152,7 @@ git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 # Only upload git metadata if diff aware is enabled.
 if [ "$DIFF_AWARE" = "true" ]; then
     echo "Upload git metadata"
-    ${DATADOG_CLI_PATH} git-metadata upload || exit 1
+    ${DATADOG_CLI_PATH} git-metadata upload
     echo "Done"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -149,9 +149,12 @@ echo "Done: will output results at $OUTPUT_FILE"
 cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
-echo "Upload git metadata"
-${DATADOG_CLI_PATH} git-metadata upload || exit 1
-echo "Done"
+# Only upload git metadata if diff aware is enabled.
+if [ "$DIFF_AWARE" = "true" ]; then
+    echo "Upload git metadata"
+    ${DATADOG_CLI_PATH} git-metadata upload || exit 1
+    echo "Done"
+fi
 
 echo "Starting Static Analysis"
 $CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION $DIFF_AWARE_VALUE|| exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,6 +81,12 @@ else
     SUBDIRECTORY_OPTION="--subdirectory ${SUBDIRECTORY}"
 fi
 
+if [ "$DIFF_AWARE" = "true" ]; then
+    DIFF_AWARE_VALUE="--diff-aware"
+else
+    DIFF_AWARE_VALUE=""
+fi
+
 # verify ARCHITECTURE is x86_64 or aarch64
 if [ "$ARCHITECTURE" != "x86_64" ] && [ "$ARCHITECTURE" != "aarch64" ]; then
     echo "ARCHITECTURE must be x86_64 or aarch64"
@@ -144,7 +150,7 @@ cd ${GITHUB_WORKSPACE} || exit 1
 git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 echo "Starting Static Analysis"
-$CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION|| exit 1
+$CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION $DIFF_AWARE_VALUE|| exit 1
 echo "Done"
 
 echo "Uploading Static Analysis Results to Datadog"


### PR DESCRIPTION
## What problem are you trying to solve?

The `datadog-static-analyzer` now supports a diff-aware scan mode that we'd like to support in this GitHub Action.

## What is your solution?

Include an option to enable diff-aware mode. Default is `false` (disabled)

## What the reviewer should know

Since we accept `DATADOG_SITE` and `DD_SITE` env vars, we've made this change ([PR](https://github.com/DataDog/datadog-ci/pull/1256)) in the `datadog-ci git-metadata update` command. If that PR is rejected, we will need to add additional logic in this action.