### PR TITLE
[STAL-1164] Add secrets scanning feature flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "Get the execution time statistics for analyzed files."
     required: false
     default: "false"
+  enable_secrets:
+    description: "(Currently for internal use) Enable secrets scanning"
+    required: false
+    default: "false"
   debug:
     description: "Lets the analyzer print additional logs useful for debugging."
     required: false
@@ -62,6 +66,7 @@ runs:
     CPU_COUNT: ${{ inputs.cpu_count }}
     ENABLE_PERFORMANCE_STATISTICS: ${{ inputs.enable_performance_statistics }}
     ENABLE_DEBUG: ${{ inputs.debug }}
+    ENABLE_SECRETS: ${{ inputs.enable_secrets }}
     SUBDIRECTORY: ${{ inputs.subdirectory }}
     SCA_ENABLED: ${{ inputs.sca_enabled }}
     ARCHITECTURE: ${{ inputs.architecture }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,6 +75,12 @@ else
     DEBUG_ARGUMENT_VALUE="no"
 fi
 
+if [ "$ENABLE_SECRETS" = "true" ]; then
+    ENABLE_SECRETS_FLAG="--test-secrets"
+else
+    ENABLE_SECRETS_FLAG=""
+fi
+
 if [ -z "$SUBDIRECTORY" ]; then
     SUBDIRECTORY_OPTION=""
 else
@@ -157,7 +163,7 @@ if [ "$DIFF_AWARE" = "true" ]; then
 fi
 
 echo "Starting Static Analysis"
-$CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION $DIFF_AWARE_VALUE|| exit 1
+$CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" "$ENABLE_SECRETS_FLAG" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION $DIFF_AWARE_VALUE|| exit 1
 echo "Done"
 
 echo "Uploading Static Analysis Results to Datadog"


### PR DESCRIPTION
Adds `enable_secrets` as a GitHub action feature flag, disabled by default.

## What the reviewer should know
* This flag (and related documentation) will be added to `README.md` when the secrets scanning functionality moves to private beta.