### PR TITLE
Fix GitHub action for diff-aware scanning

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -157,6 +157,10 @@ git config --global --add safe.directory ${GITHUB_WORKSPACE} || exit 1
 
 # Only upload git metadata if diff aware is enabled.
 if [ "$DIFF_AWARE" = "true" ]; then
+    echo "Disabling extensions.worktreeConfig"
+    git config --unset extensions.worktreeConfig
+    echo "Done"
+
     echo "Upload git metadata"
     ${DATADOG_CLI_PATH} git-metadata upload
     echo "Done"


### PR DESCRIPTION
## What problem are you trying to solve?

Our static analyzer fails when diff-aware is enabled. 

## Solution

We checked what is the failure and the static analyzer [reports](https://github.com/DataDog/datadog-ci/actions/runs/8805604169/job/24168547593)

```
error when trying to enabled diff-aware scanning: unsupported extension name extensions.worktreeconfig; class=Repository (6)
```

The workaround is to disable the `worktreeConfig` extension.

The solution is then to use `git config --unset extensions.worktreeConfig` before we run `datadog-ci git-metadata upload`


## Testing

We made a commit on `datadog-ci` to use this branch of the action. It runs without an issue (see results [here](https://github.com/DataDog/datadog-ci/actions/runs/8806418316)).