### PR TITLE
Fix release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ git push --tags
 3. Replace the tag pointing to the major version using to the same commit than the `vX.Y.Z` tag.
 ```
 git tag --delete vX
-git push --delete vX
+git push --delete origin v1
 git tag vX 
 git push --tags
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ git push --tags
 3. Replace the tag pointing to the major version using to the same commit than the `vX.Y.Z` tag.
 ```
 git tag --delete vX
-git push --delete origin v1
+git push --delete origin vX
 git tag vX 
 git push --tags
 ```


### PR DESCRIPTION
## What problem are you trying to solve?

The instructions to release seem incorrect


```
git push --delete v1
fatal: --delete doesn't make sense without any refs
```

### Solution

Use `git push --delete origin vX`

```
git push --delete origin v1
To github.com:DataDog/datadog-static-analyzer-github-action.git
 - [deleted]         v1
```