### PR TITLE
Remove unused test flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,6 @@ inputs:
     description: "Get the execution time statistics for analyzed files."
     required: false
     default: "false"
-  enable_secrets:
-    description: "(Currently for internal use) Enable secrets scanning"
-    required: false
-    default: "false"
   debug:
     description: "Lets the analyzer print additional logs useful for debugging."
     required: false
@@ -66,7 +62,6 @@ runs:
     CPU_COUNT: ${{ inputs.cpu_count }}
     ENABLE_PERFORMANCE_STATISTICS: ${{ inputs.enable_performance_statistics }}
     ENABLE_DEBUG: ${{ inputs.debug }}
-    ENABLE_SECRETS: ${{ inputs.enable_secrets }}
     SUBDIRECTORY: ${{ inputs.subdirectory }}
     SCA_ENABLED: ${{ inputs.sca_enabled }}
     ARCHITECTURE: ${{ inputs.architecture }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,12 +75,6 @@ else
     DEBUG_ARGUMENT_VALUE="no"
 fi
 
-if [ "$ENABLE_SECRETS" = "true" ]; then
-    ENABLE_SECRETS_FLAG="--test-secrets"
-else
-    ENABLE_SECRETS_FLAG=""
-fi
-
 if [ -z "$SUBDIRECTORY" ]; then
     SUBDIRECTORY_OPTION=""
 else
@@ -167,7 +161,7 @@ if [ "$DIFF_AWARE" = "true" ]; then
 fi
 
 echo "Starting Static Analysis"
-$CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" "$ENABLE_SECRETS_FLAG" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION $DIFF_AWARE_VALUE|| exit 1
+$CLI_LOCATION -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION $DIFF_AWARE_VALUE|| exit 1
 echo "Done"
 
 echo "Uploading Static Analysis Results to Datadog"


### PR DESCRIPTION
The `--test-secrets` flag was used as a smoke test for the secrets scanner. It is no longer necessary in the GitHub Action.