### PR TITLE
Remove SCA from GitHub action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,6 @@ FROM ubuntu:22.04
 RUN apt-get update
 RUN apt-get install -y git unzip curl ca-certificates gnupg
 
-# Install trivy
-RUN apt-get install -y wget apt-transport-https gnupg lsb-release
-RUN wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | apt-key add -
-RUN echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | tee -a /etc/apt/sources.list.d/trivy.list
-RUN apt-get update
-RUN apt-get install -y trivy
-
 # Install node 16
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 ENV NODE_MAJOR=16

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -6,4 +6,3 @@ util-linux,core,GPL-2.0,"The Authors: https://github.com/util-linux/util-linux/b
 git,https://github.com/git/git,GPL-2.0,© 2005-2023, Linus Torvalds and others.
 ca-certificate,core,GPL-2+,"Various Debian Contributors"
 gnupg,core,GPL-3+,"1992, 1995-2020, Free Software Foundation, Inc"
-trivy,https://github.com/aquasecurity/trivy,Apache-2.0,"Copyright (c) 2019 Aqua Security Limited"

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: "no"
   sca_enabled:
-    description: "Enable Software Composition Analysis (SCA)"
+    description: "Enable Software Composition Analysis (SCA) - DEPRECATED"
     required: false
     default: "false"
   subdirectory:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -137,19 +137,5 @@ echo "Done"
 # SCA/SBOM
 ########################################################
 if [ "${SCA_ENABLED}" = "true" ] || [ "${SCA_ENABLED}" = "yes" ]; then
-  SCA_OUTPUT_FILE="$OUTPUT_DIRECTORY/trivy.json"
-  echo "Generating SBOM"
-  trivy fs --output "${SCA_OUTPUT_FILE}" --format cyclonedx . > /dev/null 2>&1
-
-  if [ -f "${SCA_OUTPUT_FILE}" ]; then
-    echo "Uploading SBOM to Datadog"
-    DD_BETA_COMMANDS_ENABLED=1 ${DATADOG_CLI_PATH} sbom upload --service "$DD_SERVICE" --env "$DD_ENV" "${SCA_OUTPUT_FILE}" || exit 1
-    echo "Done"
-  else
-    echo "SBOM not generated, not uploading"
-    exit 1
-  fi
-  echo "Done"
-else
-  echo "SCA not enabled (sca_enabled value ${SCA_ENABLED}), skipping"
+  echo "SCA no longer supported in this GitHub action, use https://github.com/DataDog/datadog-sca-github-action"
 fi


### PR DESCRIPTION
SCA is now handled through [this GitHub action](https://github.com/DataDog/datadog-sca-github-action). Removing the SCA and mark it deprecated.