### PR TITLE
[STAL-2778] Add note about using the `code_analysis_read` scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
           enable_performance_statistics: false
 ```
 
-You **must** set your Datadog API and application keys as [secrets in your GitHub repository][4] whether at the organization or repository level. Please add the `code_analysis_read` scope to your Datadog application key requ the. For more information, see [API and Application Keys][2].
+You **must** set your Datadog API and application keys as [secrets in your GitHub repository][4] whether at the organization or repository level. You must also ensure that you add the `code_analysis_read` scope to your Datadog application key. For more information, see [API and Application Keys][2].
 
 Make sure to replace `dd_site` with the Datadog site you are using[3].
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
           enable_performance_statistics: false
 ```
 
-You **must** set your Datadog API and application keys as [secrets in your GitHub repository][4] whether at the organization or repository level. You must also ensure that you add the `code_analysis_read` scope to your Datadog application key. For more information, see [API and Application Keys][2].
+You **must** set your Datadog API and application keys as [secrets in your GitHub repository][4] whether at the organization or repository level. Ensure that you add the `code_analysis_read` scope to your Datadog application key. For more information, see [API and Application Keys][2].
 
 Make sure to replace `dd_site` with the Datadog site you are using[3].
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
           enable_performance_statistics: false
 ```
 
-You **must** set your Datadog API and application keys as [secrets in your GitHub repository][4] whether at the organization or repository level. For more information, see [API and Application Keys][2].
+You **must** set your Datadog API and application keys as [secrets in your GitHub repository][4] whether at the organization or repository level. Please add the `code_analysis_read` scope to your Datadog application key requ the. For more information, see [API and Application Keys][2].
 
 Make sure to replace `dd_site` with the Datadog site you are using[3].
 


### PR DESCRIPTION
This PR adds a small change to the README to note that the Datadog application key requires the `code_analysis_read` scope.