### PR TITLE
[STAL-3099] Remove env and service

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ jobs:
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
-          dd_service: "my-service"
-          dd_env: "ci"
           dd_site: "datadoghq.com"
           cpu_count: 2
           enable_performance_statistics: false
@@ -46,8 +44,6 @@ You can set the following parameters for Static Analysis.
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
 | `dd_api_key` | Your Datadog API key. This key is created by your [Datadog organization][2] and should be stored as a [secret][2].                                      | Yes     |                 |
 | `dd_app_key` | Your Datadog application key. This key is created by your [Datadog organization][2] and should be stored as a [secret][4].                              | Yes     |                 |
-| `dd_service` | The service you want your results tagged with.                                                                                                          | Yes     |                 |
-| `dd_env`     | The environment you want your results tagged with. Datadog recommends using `ci` as the value for this input.                                           | No      | `none`          |
 | `dd_site`    | The [Datadog site][3] to send information to.                                                                                                           | No      | `datadoghq.com` |
 | `cpu_count`  | Set the number of CPUs used to by the analyzer.                                                                                                         | No      | `2`             |
 | `enable_performance_statistics` | Get the execution time statistics for analyzed files.                                                                                                   | No      | `false`         |

--- a/action.yml
+++ b/action.yml
@@ -13,14 +13,6 @@ inputs:
     description: "Your Datadog Application key used to authenticate requests."
     required: true
     default: ""
-  dd_service:
-    description: "The service you want your results tagged with."
-    required: true
-    default: ""
-  dd_env:
-    description: "The environment you want your results tagged with."
-    required: false
-    default: "none"
   dd_site:
     description: "The Datadog site. For example, users in the EU may want to set datadoghq.eu."
     required: false
@@ -64,8 +56,6 @@ runs:
   env:
     DD_API_KEY: ${{ inputs.dd_api_key }}
     DD_APP_KEY: ${{ inputs.dd_app_key }}
-    DD_SERVICE: ${{ inputs.dd_service }}
-    DD_ENV: ${{ inputs.dd_env }}
     DD_SITE: ${{ inputs.dd_site }}
     CPU_COUNT: ${{ inputs.cpu_count }}
     ENABLE_PERFORMANCE_STATISTICS: ${{ inputs.enable_performance_statistics }}


### PR DESCRIPTION
## What problem are you trying to solve?

Remove `service` and `env` as we do not want to have the user specify them.

## Solution

Remove them from the GitHub action.


## Testing

See here https://github.com/DataDog/datadog-static-analyzer-test-repo/actions/runs/11664561121/job/32475339303 

## Notes

Should be tested and merged only after [this PR](https://github.com/DataDog/datadog-static-analyzer/pull/545) is merged.