### PR TITLE
Add input deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ You can set the following parameters for Static Analysis.
 1. Diff-aware scanning only scans the files modified by a commit when analyzing feature branches. Diff-aware is enabled by default. To disable diff-aware scanning, set the GitHub action `diff_aware` parameter to `false`.
 2. Secrets scanning is in private beta. To enable secrets scanning, please contact your Datadog customer success manager.
 
+### Deprecated Inputs
+The following action inputs have been deprecated and no longer have any effect. Passing these in will emit a warning.
+* `dd_service`
+* `dd_env`
 
 ## Customizing rules
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,12 @@ inputs:
     description: "Enable diff aware scanning mode."
     required: false
     default: "true"
+  dd_service:
+    description: "(Deprecated)"
+    deprecationMessage: "The Datadog service is no longer configurable"
+  dd_env:
+    description: "(Deprecated)"
+    deprecationMessage: "The Datadog env is no longer configurable"
 runs:
   using: "docker"
   image: "docker://ghcr.io/datadog/datadog-static-analyzer:latest"


### PR DESCRIPTION
In https://github.com/DataDog/datadog-static-analyzer/pull/545, we removed support for the DD_SERVICE and DD_ENV environment variables in the GitHub action.

In https://github.com/DataDog/datadog-static-analyzer-github-action/pull/47, we stopped passing these variables in and removed `dd_service` and `dd_env` as GitHub action inputs.

Users may be using an unpinned version of this action within their own workflows, and may have manually configured `dd_service` and `dd_env`. They currently will receive errors in their workflows because the inputs are not defined.

This PR adds these inputs back but annotates them with a "[deprecationMessage](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddeprecationmessage)".

