### PR TITLE
Enable/Disable static analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,28 +40,24 @@ Make sure to replace `dd_site` with the Datadog site you are using[3].
 
 You can set the following parameters for Static Analysis.
 
-| Name         | Description                                                                                                                                             | Required | Default         |
-|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
-| `dd_api_key` | Your Datadog API key. This key is created by your [Datadog organization][2] and should be stored as a [secret][2].                                      | Yes     |                 |
-| `dd_app_key` | Your Datadog application key. This key is created by your [Datadog organization][2] and should be stored as a [secret][4].                              | Yes     |                 |
-| `dd_site`    | The [Datadog site][3] to send information to.                                                                                                           | No      | `datadoghq.com` |
-| `cpu_count`  | Set the number of CPUs used to by the analyzer.                                                                                                         | No      | `2`             |
+| Name                            | Description                                                                                                                                             | Required | Default         |
+|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
+| `dd_api_key`                    | Your Datadog API key. This key is created by your [Datadog organization][2] and should be stored as a [secret][2].                                      | Yes     |                 |
+| `dd_app_key`                    | Your Datadog application key. This key is created by your [Datadog organization][2] and should be stored as a [secret][4].                              | Yes     |                 |
+| `dd_site`                       | The [Datadog site][3] to send information to.                                                                                                           | No      | `datadoghq.com` |
+| `cpu_count`                     | Set the number of CPUs used to by the analyzer.                                                                                                         | No      | `2`             |
 | `enable_performance_statistics` | Get the execution time statistics for analyzed files.                                                                                                   | No      | `false`         |
-| `debug`      | Lets the analyzer print additional logs useful for debugging. To enable, set to `yes`.                                                                  | No      | `no`            |
-| `subdirectory` | A subdirectory pattern or glob (or space-delimited subdirectory patterns) that the analysis should be limited to. For example: "src" or "src packages". | `false` |                 |
-| `architecture` | The CPU architecture to use for the analyzer. Supported values are `x86_64` and `aarch64`.                                                              | No      | `x86_64`        |
-| `diff_aware` | Enable [diff-aware scanning mode][5].                                                                                                                   | No      | `true`          |
-| `secrets_enabled` | Enable secrets detection (in private beta)                                                                                                              | No      | `false`         |
-
+| `debug`                         | Lets the analyzer print additional logs useful for debugging. To enable, set to `yes`.                                                                  | No      | `no`            |
+| `subdirectory`                  | A subdirectory pattern or glob (or space-delimited subdirectory patterns) that the analysis should be limited to. For example: "src" or "src packages". | `false` |                 |
+| `architecture`                  | The CPU architecture to use for the analyzer. Supported values are `x86_64` and `aarch64`.                                                              | No      | `x86_64`        |
+| `diff_aware`                    | Enable [diff-aware scanning mode][5].                                                                                                                   | No      | `true`          |
+| `secrets_enabled`               | Enable secrets detection (in private beta)                                                                                                              | No      | `false`         |
+| `static_analysis_enabled`       | Enable static analysis                                                                                                                                  | No      | `true`          |
+ 
 ### Notes
 
 1. Diff-aware scanning only scans the files modified by a commit when analyzing feature branches. Diff-aware is enabled by default. To disable diff-aware scanning, set the GitHub action `diff_aware` parameter to `false`.
 2. Secrets scanning is in private beta. To enable secrets scanning, please contact your Datadog customer success manager.
-
-### Deprecated Inputs
-The following action inputs have been deprecated and no longer have any effect. Passing these in will emit a warning.
-* `dd_service`
-* `dd_env`
 
 ## Customizing rules
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can set the following parameters for Static Analysis.
 | `subdirectory`                  | A subdirectory pattern or glob (or space-delimited subdirectory patterns) that the analysis should be limited to. For example: "src" or "src packages". | `false` |                 |
 | `architecture`                  | The CPU architecture to use for the analyzer. Supported values are `x86_64` and `aarch64`.                                                              | No      | `x86_64`        |
 | `diff_aware`                    | Enable [diff-aware scanning mode][5].                                                                                                                   | No      | `true`          |
-| `secrets_enabled`               | Enable secrets detection (in private beta)                                                                                                              | No      | `false`         |
+| `secrets_enabled`               | Enable secrets detection (Limited Availability)                                                                                                         | No      | `false`         |
 | `static_analysis_enabled`       | Enable static analysis                                                                                                                                  | No      | `true`          |
  
 ### Notes

--- a/action.yml
+++ b/action.yml
@@ -29,14 +29,14 @@ inputs:
     description: "Lets the analyzer print additional logs useful for debugging."
     required: false
     default: "no"
-  sca_enabled:
-    description: "Enable Software Composition Analysis (SCA) - DEPRECATED"
-    required: false
-    default: "false"
   secrets_enabled:
-    description: "Enable Secrets Detection - BETA"
+    description: "Enable Secrets (Limited Availability)"
     required: false
     default: "false"
+  static_analysis_enabled:
+    description: "Enable Static Analysis"
+    required: false
+    default: "true"
   subdirectory:
     description: 'A subdirectory pattern or glob (or space-delimited subdirectory patterns) that the analysis should be limited to. For example: "src" or "src packages".'
     required: false
@@ -49,12 +49,6 @@ inputs:
     description: "Enable diff aware scanning mode."
     required: false
     default: "true"
-  dd_service:
-    description: "(Deprecated)"
-    deprecationMessage: "The Datadog service is no longer configurable"
-  dd_env:
-    description: "(Deprecated)"
-    deprecationMessage: "The Datadog env is no longer configurable"
 runs:
   using: "docker"
   image: "docker://ghcr.io/datadog/datadog-static-analyzer:latest"
@@ -67,7 +61,7 @@ runs:
     ENABLE_PERFORMANCE_STATISTICS: ${{ inputs.enable_performance_statistics }}
     ENABLE_DEBUG: ${{ inputs.debug }}
     SUBDIRECTORY: ${{ inputs.subdirectory }}
-    SCA_ENABLED: ${{ inputs.sca_enabled }}
     ARCHITECTURE: ${{ inputs.architecture }}
     DIFF_AWARE: ${{ inputs.diff_aware }}
     SECRETS_ENABLED: ${{ inputs.secrets_enabled }}
+    STATIC_ANALYSIS_ENABLED: ${{ inputs.static_analysis_enabled }}


### PR DESCRIPTION
## What problem are you trying to solve?

We want to be able to deactivate static analysis if the customer only wants to run secrets scanning.

## Solution

Add a new configuration option to enable/disable static analysis. It will pass an environment variable used by our github action script in the docker image for the analyzer.

[Related static-analyzer PR](https://github.com/DataDog/datadog-static-analyzer/pull/624)